### PR TITLE
Fix raw sockets IP sniffer and add menu option to select interface.

### DIFF
--- a/CasualMeter.Common/Entities/Settings.cs
+++ b/CasualMeter.Common/Entities/Settings.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -41,6 +42,12 @@ namespace CasualMeter.Common.Entities
 
         [DefaultValue(false)]
         public bool UseGlobalHotkeys { get; set; }
+
+        [DefaultValue(false)]
+        public bool UseRawSockets { get; set; }
+
+        [DefaultValue(null)]
+        public IPAddress LocalIpAddress { get; set; }
 
         //since you can't set DefaultValueAttribute on objects
         private HotKeySettings _hotkeys;

--- a/CasualMeter/CasualMeter.csproj
+++ b/CasualMeter/CasualMeter.csproj
@@ -245,6 +245,10 @@
       <Project>{1f43f250-51f4-4ddf-b0db-17dcaf175cdc}</Project>
       <Name>CasualMeter.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NetworkSniffer\NetworkSniffer.csproj">
+      <Project>{5B431143-1A77-44FF-8BC3-926FEC8AD97C}</Project>
+      <Name>NetworkSniffer</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Tera.Core\Tera.Core.csproj">
       <Project>{ee476c7c-2942-4ba4-ab47-7adbe65635fd}</Project>
       <Name>Tera.Core</Name>

--- a/CasualMeter/ShellView.xaml
+++ b/CasualMeter/ShellView.xaml
@@ -154,6 +154,38 @@
                                   HorizontalAlignment="Right"
                                   Margin="0,6,1,0"/>
                     </Grid>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0">Use Raw Sockets instead of WinPcap</TextBlock>
+                        <CheckBox Grid.Column="1" x:Name="UseRawSockets"
+                                  IsChecked="{Binding UseRawSockets}"
+                                  HorizontalAlignment="Right"
+                                  Margin="0,6,1,0"/>
+                    </Grid>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0">Bind to which local IP?</TextBlock>
+                        <ComboBox Grid.Column="1" x:Name="LocalIpAddress"
+                                  IsEnabled="{Binding UseRawSockets}"
+                                  IsEditable="False"
+                                  SelectedItem="{Binding LocalIpAddress}"
+                                  ItemsSource="{Binding AllLocalIpAddresses}"
+                                  HorizontalAlignment="Right"
+                                  Margin="0,6,1,0"
+                                  >
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Path=.}" Foreground="Black" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                    </Grid>
                 </StackPanel>
             </Border>
             <ItemsControl Background="Transparent" Width="{StaticResource Width}"
@@ -234,7 +266,7 @@
                             <Setter Property="Width" Value="{StaticResource Width}"/>
                             <Setter Property="BorderThickness" Value="1"/>
                             <Setter Property="BorderBrush" Value="{StaticResource BrushWhite}"/>
-                            </Style>
+                        </Style>
                     </Grid.Resources>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>


### PR DESCRIPTION
This allows CasualMeter to work when using BattlePing etc.

Seems to require Windows Firewall to be turned off.

I haven't tested WinPcap variant.