### PR TITLE
Force refresh topmost on toggle isPinned

### DIFF
--- a/CasualMeter.Common/Conductors/CasualMessenger.cs
+++ b/CasualMeter.Common/Conductors/CasualMessenger.cs
@@ -32,11 +32,12 @@ namespace CasualMeter.Common.Conductors
             Messenger.Send(new PastePlayerStatsMessage());
         }
 
-        public void RefreshVisibility(bool? isVisible)
+        public void RefreshVisibility(bool? isVisible, bool toggle)
         {
             Messenger.Send(new RefreshVisibilityMessage
             {
-                IsVisible = isVisible
+                IsVisible = isVisible,
+                Toggle = toggle
             });
         }
 

--- a/CasualMeter.Common/Conductors/Messages/RefreshVisibilityMessage.cs
+++ b/CasualMeter.Common/Conductors/Messages/RefreshVisibilityMessage.cs
@@ -9,5 +9,6 @@ namespace CasualMeter.Common.Conductors.Messages
     public class RefreshVisibilityMessage
     {
         public bool? IsVisible { get; set; }
+        public bool Toggle { get; set; }
     }
 }

--- a/CasualMeter.Common/Helpers/ProcessHelper.cs
+++ b/CasualMeter.Common/Helpers/ProcessHelper.cs
@@ -25,9 +25,9 @@ namespace CasualMeter.Common.Helpers
             //empty method to ensure initialization
         }
 
-        public void ForceVisibilityRefresh()
+        public void ForceVisibilityRefresh(bool toggle=false)
         {
-            CasualMessenger.Instance.RefreshVisibility(IsTeraActive);
+            CasualMessenger.Instance.RefreshVisibility(IsTeraActive, toggle);
         }
 
         public void UpdateHotKeys()

--- a/CasualMeter.Common/UI/Controls/CasualMeterWindow.cs
+++ b/CasualMeter.Common/UI/Controls/CasualMeterWindow.cs
@@ -60,6 +60,11 @@ namespace CasualMeter.Common.UI.Controls
             if (SettingsHelper.Instance.Settings.IsPinned)
             {
                 Visibility = Visibility.Visible;
+                if (message.Toggle)
+                {
+                    Topmost = false;
+                    Topmost = true;
+                }
                 return;
             }
             // at this point, it means that we are not pinned, so set the visibility accordingly

--- a/CasualMeter/ShellViewModel.cs
+++ b/CasualMeter/ShellViewModel.cs
@@ -89,7 +89,7 @@ namespace CasualMeter
                 SetProperty(value, onChanged: e =>
                 {
                     SettingsHelper.Instance.Settings.IsPinned = value;
-                    ProcessHelper.Instance.ForceVisibilityRefresh();
+                    ProcessHelper.Instance.ForceVisibilityRefresh(true);
                 });
             }
         }
@@ -344,7 +344,6 @@ namespace CasualMeter
         private void ToggleIsPinned()
         {
             IsPinned = !IsPinned;
-            ProcessHelper.Instance.ForceVisibilityRefresh();
         }
     }
 }


### PR DESCRIPTION
To bring back occasionally disappeared meter window via clicking on tray icon.
Compromise between constant switching topmost and full UI restart (I think stop updating UI problem is not in UI itself, but in lost packets handling or something like that).